### PR TITLE
feat: add retry logic for transient API errors (429, 5xx)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -35,6 +35,7 @@ type programConfig struct {
 	DestDir        string
 	KubeconfigPath string
 	LogLevel       string
+	MaxRetries     int
 	Projects       []string
 	Rename         bool
 	RenameTpl      string
@@ -42,7 +43,7 @@ type programConfig struct {
 }
 
 func (c programConfig) String() string {
-	return fmt.Sprintf(`{AddMetadata: %t, AuthPlugin: '%s', Concurrency: %d, ConfigFile: '%s', DestDir: '%s', KubeconfigPath: '%s', Projects: %v, Rename: %t, RenameTpl: '%s', Split: %t}`, c.AddMetadata, c.AuthPlugin, c.Concurrency, c.ConfigFile, c.DestDir, c.KubeconfigPath, c.Projects, c.Rename, c.RenameTpl, c.Split)
+	return fmt.Sprintf(`{AddMetadata: %t, AuthPlugin: '%s', Concurrency: %d, ConfigFile: '%s', DestDir: '%s', KubeconfigPath: '%s', MaxRetries: %d, Projects: %v, Rename: %t, RenameTpl: '%s', Split: %t}`, c.AddMetadata, c.AuthPlugin, c.Concurrency, c.ConfigFile, c.DestDir, c.KubeconfigPath, c.MaxRetries, c.Projects, c.Rename, c.RenameTpl, c.Split)
 }
 
 var cfg programConfig
@@ -133,6 +134,10 @@ func NewRootCmd(version, commit, date string) *cobra.Command {
 
 	rootCmd.
 		Flags().
+		Int("max-retries", 5, "Maximum number of retries for transient API errors (429, 5xx)")
+
+	rootCmd.
+		Flags().
 		StringSlice("projects", []string{}, "Projects to filter by")
 
 	rootCmd.
@@ -168,6 +173,7 @@ func run(cmd *cobra.Command, args []string) {
 	cfg.AuthPlugin = viper.GetString("auth-plugin")
 	cfg.Concurrency = viper.GetInt("concurrency")
 	cfg.DestDir = viper.GetString("dest-dir")
+	cfg.MaxRetries = viper.GetInt("max-retries")
 	cfg.Projects = viper.GetStringSlice("projects")
 	cfg.Rename = viper.GetBool("rename")
 	cfg.RenameTpl = viper.GetString("rename-tpl")
@@ -219,11 +225,11 @@ func run(cmd *cobra.Command, args []string) {
 
 	projects := cfg.Projects
 	if len(cfg.Projects) == 0 {
-		projects = getProjects()
+		projects = getProjects(cfg.MaxRetries)
 	}
 
-	go filterProjects(semaphore, projects, filteredProjects)
-	go getCredentials(semaphore, filteredProjects, credentials, cfg.AuthPlugin)
+	go filterProjects(semaphore, projects, filteredProjects, cfg.MaxRetries)
+	go getCredentials(semaphore, filteredProjects, credentials, cfg.AuthPlugin, cfg.MaxRetries)
 
 	if cfg.Split {
 		writeCredentialsToFile(credentials, cfg.DestDir, contextNameTemplate, cfg.AddMetadata)
@@ -233,13 +239,15 @@ func run(cmd *cobra.Command, args []string) {
 	}
 }
 
-func getProjects() []string {
+func getProjects(maxRetries int) []string {
 	ctx := context.Background()
 	crmService, err := crm.NewService(ctx)
 	if err != nil {
 		log.Fatalf("Failed to create cloudresourcemanager service: %v", err)
 	}
-	projects, err := crmService.Projects.List().Filter("lifecycleState:ACTIVE").Do()
+	projects, err := withRetry(maxRetries, "list-projects", func() (*crm.ListProjectsResponse, error) {
+		return crmService.Projects.List().Filter("lifecycleState:ACTIVE").Do()
+	})
 	if err != nil {
 		log.Fatalf("Failed to list projects: %v", err)
 	}
@@ -250,7 +258,7 @@ func getProjects() []string {
 	return projectIDs
 }
 
-func filterProjects(semaphore chan struct{}, projects []string, out chan<- string) {
+func filterProjects(semaphore chan struct{}, projects []string, out chan<- string, maxRetries int) {
 	ctx := context.Background()
 	suService, err := su.NewService(ctx)
 	if err != nil {
@@ -265,7 +273,9 @@ func filterProjects(semaphore chan struct{}, projects []string, out chan<- strin
 		go func(project string) {
 			defer wg.Done()
 			defer func() { <-semaphore }()
-			containerServiceRes, err := suServicesService.Get(fmt.Sprintf("projects/%s/services/container.googleapis.com", project)).Do()
+			containerServiceRes, err := withRetry(maxRetries, "check-container-api", func() (*su.GoogleApiServiceusageV1Service, error) {
+				return suServicesService.Get(fmt.Sprintf("projects/%s/services/container.googleapis.com", project)).Do()
+			})
 			if err != nil {
 				log.WithField("projectID", project).Errorf("Failed to get container service: %v", err)
 				return
@@ -279,7 +289,7 @@ func filterProjects(semaphore chan struct{}, projects []string, out chan<- strin
 	close(out)
 }
 
-func getCredentials(semaphore chan struct{}, in <-chan string, out chan<- credentialsData, authPlugin string) {
+func getCredentials(semaphore chan struct{}, in <-chan string, out chan<- credentialsData, authPlugin string, maxRetries int) {
 	ctx := context.Background()
 	containerService, err := cnt.NewService(ctx)
 	if err != nil {
@@ -291,7 +301,9 @@ func getCredentials(semaphore chan struct{}, in <-chan string, out chan<- creden
 		semaphore <- struct{}{}
 		go func(project string) {
 			defer wg.Done()
-			clusters, err := containerService.Projects.Locations.Clusters.List(fmt.Sprintf("projects/%s/locations/-", project)).Do()
+			clusters, err := withRetry(maxRetries, "list-clusters", func() (*cnt.ListClustersResponse, error) {
+				return containerService.Projects.Locations.Clusters.List(fmt.Sprintf("projects/%s/locations/-", project)).Do()
+			})
 			<-semaphore
 			if err != nil {
 				log.WithField("projectID", project).Errorf("Failed to list clusters: %v", err)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	yaml "gopkg.in/yaml.v3"
 
@@ -173,7 +174,7 @@ func run(cmd *cobra.Command, args []string) {
 	cfg.AuthPlugin = viper.GetString("auth-plugin")
 	cfg.Concurrency = viper.GetInt("concurrency")
 	cfg.DestDir = viper.GetString("dest-dir")
-	cfg.MaxRetries = viper.GetInt("max-retries")
+	cfg.MaxRetries = max(0, viper.GetInt("max-retries"))
 	cfg.Projects = viper.GetStringSlice("projects")
 	cfg.Rename = viper.GetBool("rename")
 	cfg.RenameTpl = viper.GetString("rename-tpl")
@@ -247,7 +248,7 @@ func getProjects(maxRetries int) []string {
 	}
 	projects, err := withRetry(maxRetries, "list-projects", func() (*crm.ListProjectsResponse, error) {
 		return crmService.Projects.List().Filter("lifecycleState:ACTIVE").Do()
-	})
+	}, time.Sleep)
 	if err != nil {
 		log.Fatalf("Failed to list projects: %v", err)
 	}
@@ -275,7 +276,7 @@ func filterProjects(semaphore chan struct{}, projects []string, out chan<- strin
 			defer func() { <-semaphore }()
 			containerServiceRes, err := withRetry(maxRetries, "check-container-api", func() (*su.GoogleApiServiceusageV1Service, error) {
 				return suServicesService.Get(fmt.Sprintf("projects/%s/services/container.googleapis.com", project)).Do()
-			})
+			}, time.Sleep)
 			if err != nil {
 				log.WithField("projectID", project).Errorf("Failed to get container service: %v", err)
 				return
@@ -303,7 +304,7 @@ func getCredentials(semaphore chan struct{}, in <-chan string, out chan<- creden
 			defer wg.Done()
 			clusters, err := withRetry(maxRetries, "list-clusters", func() (*cnt.ListClustersResponse, error) {
 				return containerService.Projects.Locations.Clusters.List(fmt.Sprintf("projects/%s/locations/-", project)).Do()
-			})
+			}, time.Sleep)
 			<-semaphore
 			if err != nil {
 				log.WithField("projectID", project).Errorf("Failed to list clusters: %v", err)

--- a/cmd/retry.go
+++ b/cmd/retry.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"errors"
-	"math"
 	"math/rand/v2"
 	"net/http"
 	"strconv"
@@ -14,7 +13,7 @@ import (
 
 // withRetry executes fn and retries on transient API errors (429, 5xx)
 // with exponential backoff and jitter.
-func withRetry[T any](maxRetries int, operation string, fn func() (T, error)) (T, error) {
+func withRetry[T any](maxRetries int, operation string, fn func() (T, error), sleepFn func(time.Duration)) (T, error) {
 	var lastErr error
 	for attempt := range maxRetries + 1 {
 		result, err := fn()
@@ -43,7 +42,7 @@ func withRetry[T any](maxRetries int, operation string, fn func() (T, error)) (T
 			"error":      err,
 		}).Warn("Retrying after transient API error")
 
-		time.Sleep(delay)
+		sleepFn(delay)
 	}
 
 	var zero T
@@ -94,18 +93,33 @@ func getRetryAfter(err error) time.Duration {
 // For 429 errors, it respects the Retry-After header if present.
 // Otherwise, it uses exponential backoff with jitter.
 func computeBackoff(attempt, statusCode int, err error) time.Duration {
-	const baseDelay = 1 * time.Second
-	const maxDelay = 60 * time.Second
+	const (
+		baseDelay = 1 * time.Second
+		maxDelay  = 60 * time.Second
+	)
 
 	var delay time.Duration
 	if statusCode == http.StatusTooManyRequests {
 		if ra := getRetryAfter(err); ra > 0 {
-			delay = ra
-		} else {
-			delay = baseDelay * time.Duration(math.Pow(2, float64(attempt)))
+			// Retry-After present: use server value with upward-only jitter [1.0, 1.5)
+			jitter := 1.0 + rand.Float64()*0.5
+			delay = time.Duration(float64(ra) * jitter)
+			if delay > maxDelay {
+				delay = maxDelay
+			}
+			return delay
 		}
+	}
+
+	// Exponential backoff using bit shift to avoid float overflow.
+	// Guard against overflow: for attempt >= 62, shift would overflow int64.
+	if attempt >= 62 {
+		delay = maxDelay
 	} else {
-		delay = baseDelay * time.Duration(math.Pow(2, float64(attempt)))
+		delay = baseDelay << attempt
+		if delay <= 0 || delay > maxDelay {
+			delay = maxDelay
+		}
 	}
 
 	// Add jitter: multiply by random factor in [0.5, 1.5)

--- a/cmd/retry.go
+++ b/cmd/retry.go
@@ -1,0 +1,119 @@
+package cmd
+
+import (
+	"errors"
+	"math"
+	"math/rand/v2"
+	"net/http"
+	"strconv"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"google.golang.org/api/googleapi"
+)
+
+// withRetry executes fn and retries on transient API errors (429, 5xx)
+// with exponential backoff and jitter.
+func withRetry[T any](maxRetries int, operation string, fn func() (T, error)) (T, error) {
+	var lastErr error
+	for attempt := range maxRetries + 1 {
+		result, err := fn()
+		if err == nil {
+			return result, nil
+		}
+		lastErr = err
+
+		statusCode, retryable := isRetryableError(err)
+		if !retryable {
+			var zero T
+			return zero, err
+		}
+
+		if attempt == maxRetries {
+			break
+		}
+
+		delay := computeBackoff(attempt, statusCode, err)
+		log.WithFields(log.Fields{
+			"operation":  operation,
+			"attempt":    attempt + 1,
+			"maxRetries": maxRetries,
+			"statusCode": statusCode,
+			"delay":      delay,
+			"error":      err,
+		}).Warn("Retrying after transient API error")
+
+		time.Sleep(delay)
+	}
+
+	var zero T
+	return zero, lastErr
+}
+
+// isRetryableError checks if the error is a transient Google API error
+// that should be retried.
+func isRetryableError(err error) (int, bool) {
+	var apiErr *googleapi.Error
+	if !errors.As(err, &apiErr) {
+		return 0, false
+	}
+	switch apiErr.Code {
+	case http.StatusTooManyRequests,
+		http.StatusInternalServerError,
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout:
+		return apiErr.Code, true
+	default:
+		return apiErr.Code, false
+	}
+}
+
+// getRetryAfter extracts the Retry-After header value from a Google API error.
+// Returns 0 if the header is absent or cannot be parsed.
+func getRetryAfter(err error) time.Duration {
+	var apiErr *googleapi.Error
+	if !errors.As(err, &apiErr) {
+		return 0
+	}
+	if apiErr.Header == nil {
+		return 0
+	}
+	ra := apiErr.Header.Get("Retry-After")
+	if ra == "" {
+		return 0
+	}
+	seconds, parseErr := strconv.Atoi(ra)
+	if parseErr != nil {
+		return 0
+	}
+	return time.Duration(seconds) * time.Second
+}
+
+// computeBackoff calculates the delay before the next retry attempt.
+// For 429 errors, it respects the Retry-After header if present.
+// Otherwise, it uses exponential backoff with jitter.
+func computeBackoff(attempt, statusCode int, err error) time.Duration {
+	const baseDelay = 1 * time.Second
+	const maxDelay = 60 * time.Second
+
+	var delay time.Duration
+	if statusCode == http.StatusTooManyRequests {
+		if ra := getRetryAfter(err); ra > 0 {
+			delay = ra
+		} else {
+			delay = baseDelay * time.Duration(math.Pow(2, float64(attempt)))
+		}
+	} else {
+		delay = baseDelay * time.Duration(math.Pow(2, float64(attempt)))
+	}
+
+	// Add jitter: multiply by random factor in [0.5, 1.5)
+	jitter := 0.5 + rand.Float64()
+	delay = time.Duration(float64(delay) * jitter)
+
+	if delay > maxDelay {
+		delay = maxDelay
+	}
+	return delay
+}

--- a/cmd/retry_test.go
+++ b/cmd/retry_test.go
@@ -1,0 +1,258 @@
+package cmd
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"google.golang.org/api/googleapi"
+)
+
+func TestIsRetryableError(t *testing.T) {
+	tests := []struct {
+		name         string
+		err          error
+		wantCode     int
+		wantRetryable bool
+	}{
+		{
+			name:         "429 Too Many Requests",
+			err:          &googleapi.Error{Code: 429},
+			wantCode:     429,
+			wantRetryable: true,
+		},
+		{
+			name:         "500 Internal Server Error",
+			err:          &googleapi.Error{Code: 500},
+			wantCode:     500,
+			wantRetryable: true,
+		},
+		{
+			name:         "502 Bad Gateway",
+			err:          &googleapi.Error{Code: 502},
+			wantCode:     502,
+			wantRetryable: true,
+		},
+		{
+			name:         "503 Service Unavailable",
+			err:          &googleapi.Error{Code: 503},
+			wantCode:     503,
+			wantRetryable: true,
+		},
+		{
+			name:         "504 Gateway Timeout",
+			err:          &googleapi.Error{Code: 504},
+			wantCode:     504,
+			wantRetryable: true,
+		},
+		{
+			name:         "400 Bad Request",
+			err:          &googleapi.Error{Code: 400},
+			wantCode:     400,
+			wantRetryable: false,
+		},
+		{
+			name:         "403 Forbidden",
+			err:          &googleapi.Error{Code: 403},
+			wantCode:     403,
+			wantRetryable: false,
+		},
+		{
+			name:         "404 Not Found",
+			err:          &googleapi.Error{Code: 404},
+			wantCode:     404,
+			wantRetryable: false,
+		},
+		{
+			name:         "non-API error",
+			err:          errors.New("some random error"),
+			wantCode:     0,
+			wantRetryable: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			code, retryable := isRetryableError(tt.err)
+			if code != tt.wantCode {
+				t.Errorf("isRetryableError() code = %d, want %d", code, tt.wantCode)
+			}
+			if retryable != tt.wantRetryable {
+				t.Errorf("isRetryableError() retryable = %v, want %v", retryable, tt.wantRetryable)
+			}
+		})
+	}
+}
+
+func TestGetRetryAfter(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want time.Duration
+	}{
+		{
+			name: "valid Retry-After header",
+			err: &googleapi.Error{
+				Code:   429,
+				Header: http.Header{"Retry-After": []string{"30"}},
+			},
+			want: 30 * time.Second,
+		},
+		{
+			name: "no header",
+			err:  &googleapi.Error{Code: 429},
+			want: 0,
+		},
+		{
+			name: "empty Retry-After",
+			err: &googleapi.Error{
+				Code:   429,
+				Header: http.Header{"Retry-After": []string{""}},
+			},
+			want: 0,
+		},
+		{
+			name: "unparseable Retry-After",
+			err: &googleapi.Error{
+				Code:   429,
+				Header: http.Header{"Retry-After": []string{"not-a-number"}},
+			},
+			want: 0,
+		},
+		{
+			name: "non-API error",
+			err:  errors.New("random error"),
+			want: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getRetryAfter(tt.err)
+			if got != tt.want {
+				t.Errorf("getRetryAfter() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestComputeBackoff(t *testing.T) {
+	t.Run("exponential growth", func(t *testing.T) {
+		err := &googleapi.Error{Code: 500}
+		prev := time.Duration(0)
+		for attempt := range 4 {
+			delay := computeBackoff(attempt, 500, err)
+			// With jitter in [0.5, 1.5), for attempt 0 base is 1s,
+			// so delay should be in [0.5s, 1.5s)
+			if delay <= 0 {
+				t.Errorf("attempt %d: delay should be positive, got %v", attempt, delay)
+			}
+			if attempt > 0 && delay < prev/4 {
+				// Very rough check that delays grow (accounting for jitter)
+				t.Logf("attempt %d: delay %v (prev %v) - growth looks suspicious", attempt, delay, prev)
+			}
+			prev = delay
+		}
+	})
+
+	t.Run("respects Retry-After for 429", func(t *testing.T) {
+		err := &googleapi.Error{
+			Code:   429,
+			Header: http.Header{"Retry-After": []string{"10"}},
+		}
+		delay := computeBackoff(0, http.StatusTooManyRequests, err)
+		// Base is 10s, with jitter [0.5, 1.5) => [5s, 15s)
+		if delay < 5*time.Second || delay >= 15*time.Second {
+			t.Errorf("expected delay in [5s, 15s), got %v", delay)
+		}
+	})
+
+	t.Run("caps at 60 seconds", func(t *testing.T) {
+		err := &googleapi.Error{Code: 500}
+		delay := computeBackoff(10, 500, err)
+		if delay > 60*time.Second {
+			t.Errorf("delay should be capped at 60s, got %v", delay)
+		}
+	})
+}
+
+func TestWithRetry_ImmediateSuccess(t *testing.T) {
+	calls := 0
+	result, err := withRetry(3, "test-op", func() (string, error) {
+		calls++
+		return "ok", nil
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result != "ok" {
+		t.Errorf("expected 'ok', got %q", result)
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 call, got %d", calls)
+	}
+}
+
+func TestWithRetry_TransientThenSuccess(t *testing.T) {
+	calls := 0
+	result, err := withRetry(3, "test-op", func() (string, error) {
+		calls++
+		if calls <= 2 {
+			return "", &googleapi.Error{Code: 429}
+		}
+		return "ok", nil
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result != "ok" {
+		t.Errorf("expected 'ok', got %q", result)
+	}
+	if calls != 3 {
+		t.Errorf("expected 3 calls, got %d", calls)
+	}
+}
+
+func TestWithRetry_ExhaustedRetries(t *testing.T) {
+	calls := 0
+	_, err := withRetry(2, "test-op", func() (string, error) {
+		calls++
+		return "", &googleapi.Error{Code: 429, Message: "rate limited"}
+	})
+	if err == nil {
+		t.Fatal("expected error after exhausting retries")
+	}
+	// 1 initial + 2 retries = 3 calls
+	if calls != 3 {
+		t.Errorf("expected 3 calls (1 initial + 2 retries), got %d", calls)
+	}
+}
+
+func TestWithRetry_NonRetryableError(t *testing.T) {
+	calls := 0
+	_, err := withRetry(3, "test-op", func() (string, error) {
+		calls++
+		return "", &googleapi.Error{Code: 403, Message: "forbidden"}
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 call (no retry for 403), got %d", calls)
+	}
+}
+
+func TestWithRetry_ZeroRetries(t *testing.T) {
+	calls := 0
+	_, err := withRetry(0, "test-op", func() (string, error) {
+		calls++
+		return "", &googleapi.Error{Code: 429}
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 call with 0 retries, got %d", calls)
+	}
+}

--- a/cmd/retry_test.go
+++ b/cmd/retry_test.go
@@ -9,65 +9,67 @@ import (
 	"google.golang.org/api/googleapi"
 )
 
+var noSleep = func(time.Duration) {}
+
 func TestIsRetryableError(t *testing.T) {
 	tests := []struct {
-		name         string
-		err          error
-		wantCode     int
+		name          string
+		err           error
+		wantCode      int
 		wantRetryable bool
 	}{
 		{
-			name:         "429 Too Many Requests",
-			err:          &googleapi.Error{Code: 429},
-			wantCode:     429,
+			name:          "429 Too Many Requests",
+			err:           &googleapi.Error{Code: 429},
+			wantCode:      429,
 			wantRetryable: true,
 		},
 		{
-			name:         "500 Internal Server Error",
-			err:          &googleapi.Error{Code: 500},
-			wantCode:     500,
+			name:          "500 Internal Server Error",
+			err:           &googleapi.Error{Code: 500},
+			wantCode:      500,
 			wantRetryable: true,
 		},
 		{
-			name:         "502 Bad Gateway",
-			err:          &googleapi.Error{Code: 502},
-			wantCode:     502,
+			name:          "502 Bad Gateway",
+			err:           &googleapi.Error{Code: 502},
+			wantCode:      502,
 			wantRetryable: true,
 		},
 		{
-			name:         "503 Service Unavailable",
-			err:          &googleapi.Error{Code: 503},
-			wantCode:     503,
+			name:          "503 Service Unavailable",
+			err:           &googleapi.Error{Code: 503},
+			wantCode:      503,
 			wantRetryable: true,
 		},
 		{
-			name:         "504 Gateway Timeout",
-			err:          &googleapi.Error{Code: 504},
-			wantCode:     504,
+			name:          "504 Gateway Timeout",
+			err:           &googleapi.Error{Code: 504},
+			wantCode:      504,
 			wantRetryable: true,
 		},
 		{
-			name:         "400 Bad Request",
-			err:          &googleapi.Error{Code: 400},
-			wantCode:     400,
+			name:          "400 Bad Request",
+			err:           &googleapi.Error{Code: 400},
+			wantCode:      400,
 			wantRetryable: false,
 		},
 		{
-			name:         "403 Forbidden",
-			err:          &googleapi.Error{Code: 403},
-			wantCode:     403,
+			name:          "403 Forbidden",
+			err:           &googleapi.Error{Code: 403},
+			wantCode:      403,
 			wantRetryable: false,
 		},
 		{
-			name:         "404 Not Found",
-			err:          &googleapi.Error{Code: 404},
-			wantCode:     404,
+			name:          "404 Not Found",
+			err:           &googleapi.Error{Code: 404},
+			wantCode:      404,
 			wantRetryable: false,
 		},
 		{
-			name:         "non-API error",
-			err:          errors.New("some random error"),
-			wantCode:     0,
+			name:          "non-API error",
+			err:           errors.New("some random error"),
+			wantCode:      0,
 			wantRetryable: false,
 		},
 	}
@@ -162,9 +164,9 @@ func TestComputeBackoff(t *testing.T) {
 			Header: http.Header{"Retry-After": []string{"10"}},
 		}
 		delay := computeBackoff(0, http.StatusTooManyRequests, err)
-		// Base is 10s, with jitter [0.5, 1.5) => [5s, 15s)
-		if delay < 5*time.Second || delay >= 15*time.Second {
-			t.Errorf("expected delay in [5s, 15s), got %v", delay)
+		// Base is 10s, with upward-only jitter [1.0, 1.5) => [10s, 15s)
+		if delay < 10*time.Second || delay >= 15*time.Second {
+			t.Errorf("expected delay in [10s, 15s), got %v", delay)
 		}
 	})
 
@@ -175,6 +177,14 @@ func TestComputeBackoff(t *testing.T) {
 			t.Errorf("delay should be capped at 60s, got %v", delay)
 		}
 	})
+
+	t.Run("handles very large attempt without overflow", func(t *testing.T) {
+		err := &googleapi.Error{Code: 500}
+		delay := computeBackoff(100, 500, err)
+		if delay <= 0 || delay > 60*time.Second {
+			t.Errorf("expected positive delay <= 60s for large attempt, got %v", delay)
+		}
+	})
 }
 
 func TestWithRetry_ImmediateSuccess(t *testing.T) {
@@ -182,7 +192,7 @@ func TestWithRetry_ImmediateSuccess(t *testing.T) {
 	result, err := withRetry(3, "test-op", func() (string, error) {
 		calls++
 		return "ok", nil
-	})
+	}, noSleep)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -202,7 +212,7 @@ func TestWithRetry_TransientThenSuccess(t *testing.T) {
 			return "", &googleapi.Error{Code: 429}
 		}
 		return "ok", nil
-	})
+	}, noSleep)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -219,7 +229,7 @@ func TestWithRetry_ExhaustedRetries(t *testing.T) {
 	_, err := withRetry(2, "test-op", func() (string, error) {
 		calls++
 		return "", &googleapi.Error{Code: 429, Message: "rate limited"}
-	})
+	}, noSleep)
 	if err == nil {
 		t.Fatal("expected error after exhausting retries")
 	}
@@ -234,7 +244,7 @@ func TestWithRetry_NonRetryableError(t *testing.T) {
 	_, err := withRetry(3, "test-op", func() (string, error) {
 		calls++
 		return "", &googleapi.Error{Code: 403, Message: "forbidden"}
-	})
+	}, noSleep)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -248,7 +258,7 @@ func TestWithRetry_ZeroRetries(t *testing.T) {
 	_, err := withRetry(0, "test-op", func() (string, error) {
 		calls++
 		return "", &googleapi.Error{Code: 429}
-	})
+	}, noSleep)
 	if err == nil {
 		t.Fatal("expected error")
 	}


### PR DESCRIPTION
When processing many GCP projects, API rate limits (HTTP 429) cause the
tool to fail. This adds automatic retry with exponential backoff and
jitter for all Google Cloud API calls. The Retry-After header is
respected when present. A new --max-retries flag (default: 5) controls
the maximum number of retry attempts.

Closes #21

https://claude.ai/code/session_012q31pDYGQ531vJpKyb7nkn