### PR TITLE
fix: implement 429 retry logic for project and cluster service calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ gker --rename --rename-tpl "{{ .ClusterName }}"
 ### Batch size
 
 By default, `gker` processes clusters in batches of 10. You can change this value using the `--batch-size`
+flag. Requests that receive a transient `429 Too Many Requests` response are retried automatically with
+backoff before the operation fails.
 
 ### Auth plugin
 

--- a/README.md
+++ b/README.md
@@ -103,9 +103,9 @@ gker --rename --rename-tpl "{{ .ClusterName }}"
 
 ### Batch size
 
-By default, `gker` processes clusters in batches of 10. You can change this value using the `--batch-size`
+By default, `gker` processes up to 10 clusters concurrently. You can change this limit using the `--concurrency`
 flag. Requests that receive a transient `429 Too Many Requests` response are retried automatically with
-backoff before the operation fails.
+backoff before the operation ultimately fails.
 
 ### Auth plugin
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -11,16 +11,13 @@ import (
 	"strings"
 	"sync"
 
-	yaml "gopkg.in/yaml.v3"
-
 	log "github.com/sirupsen/logrus"
-
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	crm "google.golang.org/api/cloudresourcemanager/v1"
 	cnt "google.golang.org/api/container/v1"
 	su "google.golang.org/api/serviceusage/v1"
-
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	yaml "gopkg.in/yaml.v3"
 )
 
 // Name of the user to use in kubeconfig entries.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -239,7 +239,9 @@ func getProjects() []string {
 	if err != nil {
 		log.Fatalf("Failed to create cloudresourcemanager service: %v", err)
 	}
-	projects, err := crmService.Projects.List().Filter("lifecycleState:ACTIVE").Do()
+	projects, err := doWith429Retry(ctx, "list projects", func() (*crm.ListProjectsResponse, error) {
+		return crmService.Projects.List().Filter("lifecycleState:ACTIVE").Do()
+	})
 	if err != nil {
 		log.Fatalf("Failed to list projects: %v", err)
 	}
@@ -265,7 +267,9 @@ func filterProjects(semaphore chan struct{}, projects []string, out chan<- strin
 		go func(project string) {
 			defer wg.Done()
 			defer func() { <-semaphore }()
-			containerServiceRes, err := suServicesService.Get(fmt.Sprintf("projects/%s/services/container.googleapis.com", project)).Do()
+			containerServiceRes, err := doWith429Retry(ctx, "get container service", func() (*su.GoogleApiServiceusageV1Service, error) {
+				return suServicesService.Get(fmt.Sprintf("projects/%s/services/container.googleapis.com", project)).Do()
+			})
 			if err != nil {
 				log.WithField("projectID", project).Errorf("Failed to get container service: %v", err)
 				return
@@ -291,7 +295,9 @@ func getCredentials(semaphore chan struct{}, in <-chan string, out chan<- creden
 		semaphore <- struct{}{}
 		go func(project string) {
 			defer wg.Done()
-			clusters, err := containerService.Projects.Locations.Clusters.List(fmt.Sprintf("projects/%s/locations/-", project)).Do()
+			clusters, err := doWith429Retry(ctx, "list clusters", func() (*cnt.ListClustersResponse, error) {
+				return containerService.Projects.Locations.Clusters.List(fmt.Sprintf("projects/%s/locations/-", project)).Do()
+			})
 			<-semaphore
 			if err != nil {
 				log.WithField("projectID", project).Errorf("Failed to list clusters: %v", err)

--- a/cmd/retry.go
+++ b/cmd/retry.go
@@ -58,6 +58,9 @@ func doWith429Retry[T any](ctx context.Context, requestName string, do func() (T
 			return zero, err
 		}
 
+		if retryDelay > delay {
+			delay = retryDelay
+		}
 		delay *= 2
 		if delay > retry429MaxDelay {
 			delay = retry429MaxDelay
@@ -75,6 +78,9 @@ func getRetryDelay(err error, fallback time.Duration, now time.Time) (time.Durat
 
 	if apiErr.Header != nil {
 		if retryAfter, ok := parseRetryAfter(apiErr.Header.Get("Retry-After"), now); ok {
+			if retryAfter > retry429MaxDelay {
+				retryAfter = retry429MaxDelay
+			}
 			return retryAfter, true
 		}
 	}
@@ -92,6 +98,13 @@ func parseRetryAfter(value string, now time.Time) (time.Duration, bool) {
 		if seconds < 0 {
 			return 0, false
 		}
+		maxSeconds := int(retry429MaxDelay.Seconds())
+		if maxSeconds < 1 {
+			maxSeconds = 1
+		}
+		if seconds > maxSeconds {
+			seconds = maxSeconds
+		}
 		return time.Duration(seconds) * time.Second, true
 	}
 
@@ -104,5 +117,9 @@ func parseRetryAfter(value string, now time.Time) (time.Duration, bool) {
 		return 0, true
 	}
 
-	return retryTime.Sub(now), true
+	d := retryTime.Sub(now)
+	if d > retry429MaxDelay {
+		d = retry429MaxDelay
+	}
+	return d, true
 }

--- a/cmd/retry.go
+++ b/cmd/retry.go
@@ -1,0 +1,106 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strconv"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"google.golang.org/api/googleapi"
+)
+
+const (
+	retry429MaxAttempts = 5
+	retry429BaseDelay   = time.Second
+	retry429MaxDelay    = 8 * time.Second
+)
+
+var waitForRetry = func(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func doWith429Retry[T any](ctx context.Context, requestName string, do func() (T, error)) (T, error) {
+	var zero T
+	delay := retry429BaseDelay
+
+	for attempt := 1; attempt <= retry429MaxAttempts; attempt++ {
+		result, err := do()
+		if err == nil {
+			return result, nil
+		}
+
+		retryDelay, shouldRetry := getRetryDelay(err, delay, time.Now())
+		if !shouldRetry || attempt == retry429MaxAttempts {
+			return zero, err
+		}
+
+		log.WithFields(log.Fields{
+			"attempt":      attempt,
+			"maxAttempts":  retry429MaxAttempts,
+			"nextDelay":    retryDelay,
+			"requestName":  requestName,
+			"statusCode":   http.StatusTooManyRequests,
+			"backoffDelay": delay,
+		}).Warn("Request was rate limited, retrying")
+
+		if err := waitForRetry(ctx, retryDelay); err != nil {
+			return zero, err
+		}
+
+		delay *= 2
+		if delay > retry429MaxDelay {
+			delay = retry429MaxDelay
+		}
+	}
+
+	return zero, nil
+}
+
+func getRetryDelay(err error, fallback time.Duration, now time.Time) (time.Duration, bool) {
+	var apiErr *googleapi.Error
+	if !errors.As(err, &apiErr) || apiErr.Code != http.StatusTooManyRequests {
+		return 0, false
+	}
+
+	if apiErr.Header != nil {
+		if retryAfter, ok := parseRetryAfter(apiErr.Header.Get("Retry-After"), now); ok {
+			return retryAfter, true
+		}
+	}
+
+	return fallback, true
+}
+
+func parseRetryAfter(value string, now time.Time) (time.Duration, bool) {
+	if value == "" {
+		return 0, false
+	}
+
+	if seconds, err := strconv.Atoi(value); err == nil {
+		if seconds < 0 {
+			return 0, false
+		}
+		return time.Duration(seconds) * time.Second, true
+	}
+
+	retryTime, err := http.ParseTime(value)
+	if err != nil {
+		return 0, false
+	}
+
+	if retryTime.Before(now) {
+		return 0, true
+	}
+
+	return retryTime.Sub(now), true
+}

--- a/cmd/retry.go
+++ b/cmd/retry.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -63,7 +64,7 @@ func doWith429Retry[T any](ctx context.Context, requestName string, do func() (T
 		}
 	}
 
-	return zero, nil
+	panic("doWith429Retry: reached unreachable code; check retry429MaxAttempts")
 }
 
 func getRetryDelay(err error, fallback time.Duration, now time.Time) (time.Duration, bool) {
@@ -82,6 +83,7 @@ func getRetryDelay(err error, fallback time.Duration, now time.Time) (time.Durat
 }
 
 func parseRetryAfter(value string, now time.Time) (time.Duration, bool) {
+	value = strings.TrimSpace(value)
 	if value == "" {
 		return 0, false
 	}

--- a/cmd/retry_test.go
+++ b/cmd/retry_test.go
@@ -19,7 +19,6 @@ func TestDoWith429RetryImmediateSuccess(t *testing.T) {
 		attempts++
 		return "ok", nil
 	})
-
 	if err != nil {
 		t.Fatalf("doWith429Retry returned error: %v", err)
 	}
@@ -42,7 +41,6 @@ func TestDoWith429RetryRetriesThenSucceeds(t *testing.T) {
 		}
 		return "ok", nil
 	})
-
 	if err != nil {
 		t.Fatalf("doWith429Retry returned error: %v", err)
 	}
@@ -109,7 +107,6 @@ func TestDoWith429RetryHonorsRetryAfterSeconds(t *testing.T) {
 		}
 		return "ok", nil
 	})
-
 	if err != nil {
 		t.Fatalf("doWith429Retry returned error: %v", err)
 	}

--- a/cmd/retry_test.go
+++ b/cmd/retry_test.go
@@ -1,0 +1,162 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"slices"
+	"testing"
+	"time"
+
+	"google.golang.org/api/googleapi"
+)
+
+func TestDoWith429RetryImmediateSuccess(t *testing.T) {
+	restoreWaitForRetry(t, nil)
+
+	attempts := 0
+	result, err := doWith429Retry(context.Background(), "test request", func() (string, error) {
+		attempts++
+		return "ok", nil
+	})
+
+	if err != nil {
+		t.Fatalf("doWith429Retry returned error: %v", err)
+	}
+	if result != "ok" {
+		t.Fatalf("doWith429Retry returned %q, want %q", result, "ok")
+	}
+	if attempts != 1 {
+		t.Fatalf("doWith429Retry made %d attempts, want 1", attempts)
+	}
+}
+
+func TestDoWith429RetryRetriesThenSucceeds(t *testing.T) {
+	delays := restoreWaitForRetry(t, nil)
+
+	attempts := 0
+	result, err := doWith429Retry(context.Background(), "test request", func() (string, error) {
+		attempts++
+		if attempts < 3 {
+			return "", rateLimitError("")
+		}
+		return "ok", nil
+	})
+
+	if err != nil {
+		t.Fatalf("doWith429Retry returned error: %v", err)
+	}
+	if result != "ok" {
+		t.Fatalf("doWith429Retry returned %q, want %q", result, "ok")
+	}
+	if attempts != 3 {
+		t.Fatalf("doWith429Retry made %d attempts, want 3", attempts)
+	}
+	if !slices.Equal(*delays, []time.Duration{retry429BaseDelay, 2 * retry429BaseDelay}) {
+		t.Fatalf("doWith429Retry waited %v, want %v", *delays, []time.Duration{retry429BaseDelay, 2 * retry429BaseDelay})
+	}
+}
+
+func TestDoWith429RetryStopsAfterMaxAttempts(t *testing.T) {
+	delays := restoreWaitForRetry(t, nil)
+
+	attempts := 0
+	_, err := doWith429Retry(context.Background(), "test request", func() (string, error) {
+		attempts++
+		return "", rateLimitError("")
+	})
+
+	if err == nil {
+		t.Fatal("doWith429Retry returned nil error, want rate-limit error")
+	}
+	if attempts != retry429MaxAttempts {
+		t.Fatalf("doWith429Retry made %d attempts, want %d", attempts, retry429MaxAttempts)
+	}
+	if len(*delays) != retry429MaxAttempts-1 {
+		t.Fatalf("doWith429Retry waited %d times, want %d", len(*delays), retry429MaxAttempts-1)
+	}
+}
+
+func TestDoWith429RetryDoesNotRetryOtherErrors(t *testing.T) {
+	delays := restoreWaitForRetry(t, nil)
+
+	attempts := 0
+	expectedErr := &googleapi.Error{Code: http.StatusInternalServerError}
+	_, err := doWith429Retry(context.Background(), "test request", func() (string, error) {
+		attempts++
+		return "", expectedErr
+	})
+
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("doWith429Retry returned %v, want %v", err, expectedErr)
+	}
+	if attempts != 1 {
+		t.Fatalf("doWith429Retry made %d attempts, want 1", attempts)
+	}
+	if len(*delays) != 0 {
+		t.Fatalf("doWith429Retry waited %d times, want 0", len(*delays))
+	}
+}
+
+func TestDoWith429RetryHonorsRetryAfterSeconds(t *testing.T) {
+	delays := restoreWaitForRetry(t, nil)
+
+	attempts := 0
+	result, err := doWith429Retry(context.Background(), "test request", func() (string, error) {
+		attempts++
+		if attempts == 1 {
+			return "", rateLimitError("3")
+		}
+		return "ok", nil
+	})
+
+	if err != nil {
+		t.Fatalf("doWith429Retry returned error: %v", err)
+	}
+	if result != "ok" {
+		t.Fatalf("doWith429Retry returned %q, want %q", result, "ok")
+	}
+	if !slices.Equal(*delays, []time.Duration{3 * time.Second}) {
+		t.Fatalf("doWith429Retry waited %v, want %v", *delays, []time.Duration{3 * time.Second})
+	}
+}
+
+func TestParseRetryAfterHTTPDate(t *testing.T) {
+	now := time.Date(2026, time.March, 8, 10, 0, 0, 0, time.UTC)
+
+	delay, ok := parseRetryAfter("Sun, 08 Mar 2026 10:00:05 GMT", now)
+	if !ok {
+		t.Fatal("parseRetryAfter returned ok=false, want true")
+	}
+	if delay != 5*time.Second {
+		t.Fatalf("parseRetryAfter returned %v, want %v", delay, 5*time.Second)
+	}
+}
+
+func restoreWaitForRetry(t *testing.T, err error) *[]time.Duration {
+	t.Helper()
+
+	original := waitForRetry
+	delays := []time.Duration{}
+	waitForRetry = func(ctx context.Context, delay time.Duration) error {
+		delays = append(delays, delay)
+		return err
+	}
+	t.Cleanup(func() {
+		waitForRetry = original
+	})
+
+	return &delays
+}
+
+func rateLimitError(retryAfter string) error {
+	header := http.Header{}
+	if retryAfter != "" {
+		header.Set("Retry-After", retryAfter)
+	}
+
+	return &googleapi.Error{
+		Code:   http.StatusTooManyRequests,
+		Header: header,
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"gker/cmd"
-
 	log "github.com/sirupsen/logrus"
+
+	"gker/cmd"
 )
 
 var (

--- a/main.go
+++ b/main.go
@@ -1,9 +1,11 @@
 package main
 
 import (
-	"gker/cmd"
 	log "github.com/sirupsen/logrus"
+
+	"gker/cmd"
 )
+
 var (
 	version = "dev"
 	commit  = "none"

--- a/main.go
+++ b/main.go
@@ -1,11 +1,9 @@
 package main
 
 import (
-	log "github.com/sirupsen/logrus"
-
 	"gker/cmd"
+	log "github.com/sirupsen/logrus"
 )
-
 var (
 	version = "dev"
 	commit  = "none"


### PR DESCRIPTION
Added retry functionality for handling transient 429 Too Many Requests responses in the project listing and cluster retrieval processes. Updated README to document the new automatic retry behavior.

Resolve #21 